### PR TITLE
readme: clarify usage of the JWT private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Use the following script to create your first JWT signing keys:
 
 This will generate a RSA key pair and add it to the `.env` file with the following variables:
 - `JWT_SIGNING_PUBLIC_KEY`: Public key for token verification (used by the proxy)
-- `JWT_SIGNING_PRIVATE_KEY`: Private key for token signing (used by clients making the requests)
+- `JWT_SIGNING_PRIVATE_KEY`: Private key for token signing (used by the server exposing a web HTTP client allowing only specific requests)
 
 If later on you need to rotate the keys you will need to remove them manually from the .env file before exectuting the script again.
 


### PR DESCRIPTION
Saying that the client is using the private key isn't really
clear. Indeed the private key is not used by the browsers client, but
the server “client”.

I tried to clarify this by modifying the sentence.

Let me know if you have a better phrasing.