### PR TITLE
headers: make sure to forward most target response headers

### DIFF
--- a/spec/proxy_server_spec.rb
+++ b/spec/proxy_server_spec.rb
@@ -55,7 +55,15 @@ describe "ProxyServer" do
   before(:each) do
     stub_request(:get, "https://jsonplaceholder.typicode.com/posts")
       .with(headers: {"x-foo": "bar"})
-      .to_return(status: 200, body: "", headers: {})
+      .to_return(
+        status: 200,
+        body: "",
+        headers: {
+          "X-Target-Resp-Header": "Custom",
+          "Set-Cookie": "session=remove",
+          "Transfer-Encoding": "chunked"
+        }
+      )
   end
 
   context "preflight request" do
@@ -94,6 +102,12 @@ describe "ProxyServer" do
 
         it "returns 200" do
           expect(last_response.status).to eq(200)
+        end
+
+        it "fowards most headers but skips cookies and transfer encoding" do
+          expect(last_response["X-Target-Resp-Header"]).to eq("Custom")
+          expect(last_response["Set-Cookie"]).to be_nil
+          expect(last_response["Transfer-Encoding"]).to be_nil
         end
 
         context "when header name is changed via configuration" do


### PR DESCRIPTION
This commit forwards all headers from the target server response, but
removes:
- the `set-cookie` header to avoid transfering authentication data via
the proxy (it's not its role to authenticate any clients)
- the `transfer-encoding` header, because it's a [“hop-by-hop” header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding)
and not supposed to be forwarded. The proxy reads the response (and
should thus consume the `transfer-encoding` header). If one day the
proxy supports streaming responses, we will have to manually add this
header as per the HTTP spec.