### PR TITLE
fix: make sure to rewind request body before reading it

### DIFF
--- a/proxy_server.rb
+++ b/proxy_server.rb
@@ -171,6 +171,12 @@ class ProxyServer < Sinatra::Base
       # Forward request body for POST, PUT and PATCH methods
       if !%w[GET HEAD OPTIONS].include?(method) && request.body && request.content_type
         target_request.content_type = request.content_type
+        # Make sure the request body is rewinded so we can read it.
+        # in case it has already been read, e.g. for
+        # `request.form_data?` whihch is requests with content type
+        # application/x-www-form-urlencoded, the body is already read
+        # by Rack::Request.
+        request.body.rewind
         target_request.body = request.body.read
       end
 


### PR DESCRIPTION
In case of form data requests, the request body was empty and we could
not send it to the target URL. That's because Rack::Request reads it a
first time (here:
https://github.com/rack/rack/blob/45d2f874530e55b2ac77092da63b00ee979d18ba/lib/rack/request.rb#L517)

And the sinatra documentation advises to always rewind the body before
reading it. SO let's do that!